### PR TITLE
Update Dockerfile to use Tencent Cloud registry and Eclipse Temurin f…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.cn-hangzhou.aliyuncs.com/library/openjdk:17-slim AS builder
+FROM ccr.ccs.tencentyun.com/library/openjdk:17-slim AS builder
 
 WORKDIR /build
 COPY pom.xml .
@@ -10,7 +10,7 @@ COPY src ./src
 RUN mvn package -DskipTests
 
 # 运行阶段
-FROM registry.cn-hangzhou.aliyuncs.com/library/openjdk:17-slim
+FROM eclipse-temurin:17-jre-jammy
 
 WORKDIR /app
 


### PR DESCRIPTION
…or JRE

- Changed the base image in the Dockerfile to pull OpenJDK 17 from Tencent Cloud registry, enhancing build reliability.
- Updated the runtime image to use Eclipse Temurin 17 JRE, improving compatibility and support.