### PR TITLE
Update Dockerfile to use SJTU mirror for OpenJDK 17 images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mirror.tuna.tsinghua.edu.cn/openjdk:17-slim AS builder
+FROM docker.mirrors.sjtug.sjtu.edu.cn/library/openjdk:17-slim AS builder
 
 WORKDIR /build
 COPY pom.xml .
@@ -10,7 +10,7 @@ COPY src ./src
 RUN mvn package -DskipTests
 
 # 运行阶段
-FROM eclipse-temurin:17-jre-jammy
+FROM docker.mirrors.sjtug.sjtu.edu.cn/library/openjdk:17-slim
 
 WORKDIR /app
 


### PR DESCRIPTION
- Changed the base image in the Dockerfile to pull OpenJDK 17 from the SJTU mirror, ensuring improved reliability and consistency in the build process.
- Updated the runtime image to use the same SJTU mirror for OpenJDK 17, streamlining the image source.