### PR TITLE
Update Dockerfile to use Tsinghua mirror for OpenJDK 17 images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.mirrors.sjtug.sjtu.edu.cn/library/openjdk:17-slim AS builder
+FROM docker.tuna.tsinghua.edu.cn/library/openjdk:17-slim AS builder
 
 WORKDIR /build
 COPY pom.xml .
@@ -10,7 +10,7 @@ COPY src ./src
 RUN mvn package -DskipTests
 
 # 运行阶段
-FROM docker.mirrors.sjtug.sjtu.edu.cn/library/openjdk:17-slim
+FROM docker.tuna.tsinghua.edu.cn/library/openjdk:17-slim
 
 WORKDIR /app
 


### PR DESCRIPTION
- Changed the base image in the Dockerfile to pull OpenJDK 17 from the Tsinghua mirror, ensuring improved reliability and consistency in the build process.
- Updated the runtime image to use the same Tsinghua mirror for OpenJDK 17, streamlining the image source.