### PR TITLE
Update Dockerfile to use Huawei Cloud registry for OpenJDK 17 image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ COPY src ./src
 RUN mvn package -DskipTests
 
 # 运行阶段
-FROM docker.tuna.tsinghua.edu.cn/library/openjdk:17-slim
+FROM swr.cn-north-4.myhuaweicloud.com/openjdk/openjdk:17-jre
 
 WORKDIR /app
 


### PR DESCRIPTION
- Changed the base image in the Dockerfile to pull OpenJDK 17 from Huawei Cloud registry, enhancing build reliability and consistency.
- Updated the runtime image to utilize the Huawei Cloud OpenJDK 17 JRE, ensuring a streamlined image source.