### PR TITLE
Update Dockerfile to use Eclipse Temurin for OpenJDK 17 images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:17-slim AS builder
+FROM eclipse-temurin:17-jdk-jammy AS builder
 
 WORKDIR /build
 COPY pom.xml .
@@ -10,7 +10,7 @@ COPY src ./src
 RUN mvn package -DskipTests
 
 # 运行阶段
-FROM openjdk:17-jre
+FROM eclipse-temurin:17-jre-jammy
 
 WORKDIR /app
 


### PR DESCRIPTION
- Changed the base image in the Dockerfile to use Eclipse Temurin 17 JDK for the build stage, enhancing build reliability and support.
- Updated the runtime image to utilize Eclipse Temurin 17 JRE, ensuring consistency and improved compatibility.